### PR TITLE
feat: update default theme to dark and mapping color variables from figma

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -34,7 +34,7 @@ export default async function RootLayout({
         <NextIntlClientProvider>
           <ThemeProvider
             attribute="class"
-            defaultTheme="system"
+            defaultTheme="dark"
             enableSystem
             disableTransitionOnChange
           >

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -22,65 +22,116 @@
 
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+
   --color-card: var(--card);
   --color-card-foreground: var(--card-foreground);
+
   --color-popover: var(--popover);
   --color-popover-foreground: var(--popover-foreground);
+
   --color-primary: var(--primary);
   --color-primary-foreground: var(--primary-foreground);
+
   --color-secondary: var(--secondary);
   --color-secondary-foreground: var(--secondary-foreground);
+
   --color-muted: var(--muted);
   --color-muted-foreground: var(--muted-foreground);
+
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
+
   --color-destructive: var(--destructive);
+
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+
+  --color-tertiary: var(--tertiary);
+
+  --color-bg-gradient-start: var(--bg-gradient-left);
+  --color-bg-gradient-middle: var(--bg-gradient-middle);
+  --color-bg-gradient-end: var(--bg-gradient-right);
+  --color-primary-gradient-start: var(--bg-primary-gradient-start);
+  --color-primary-gradient-end: var(--bg-primary-gradient-end);
 }
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+
+  --background: oklch(85.43% 0.003 264.54);
+  --foreground: oklch(24.11% 0.0097 248.23);
+
+  --card: oklch(99.13% 0.0013 286.38);
+  --card-foreground: oklch(24.11% 0.0097 248.23);
+
+  --popover: oklch(99.13% 0.0013 286.38);
+  --popover-foreground: oklch(24.11% 0.0097 248.23);
+
+  --primary: oklch(29.92% 0.0029 17.32);
+  --primary-foreground: oklch(98.27% 0.0026 286.35);
+
+  --secondary: oklch(95.6% 0.004 286.32);
+  --secondary-foreground: oklch(24.11% 0.0097 248.23);
+
+  --muted: oklch(98.27% 0.0026 286.35);
+  --muted-foreground: oklch(85.3% 0.0111 280.45);
+
+  --accent: oklch(93.21% 0.0054 286.3);
+  --accent-foreground: oklch(24.11% 0.0097 248.23);
+
+  --destructive: oklch(62.71% 0.1936 33.34);
+
+  --border: oklch(91.04% 0.0068 277.16);
+  --input: oklch(88.73% 0.0095 286.2);
+  --ring: oklch(59.17% 0.0998 259.93);
+
+  --bg-gradient-start: oklch(85.43% 0.003 264.54);
+  --bg-gradient-middle: oklch(98.27% 0.0026 286.35);
+  --bg-gradient-end: oklch(85.43% 0.003 264.54);
+
+  --tertiary: oklch(82.926% 0.15418 76.648);
+
+  --primary-gradient-start: oklch(38.59% 0.1365 259.84);
+  --primary-gradient-end: oklch(22.77% 0.0667 260.1);
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  --background: oklch(13.7% 0.024 251.41);
+  --foreground: oklch(94.89% 0.0029 264.54);
+
+  --card: oklch(17.85% 0.0041 285.98);
+  --card-foreground: oklch(94.89% 0.0029 264.54);
+
+  --popover: oklch(17.85% 0.0041 285.98);
+  --popover-foreground: oklch(94.89% 0.0029 264.54);
+
+  --primary: oklch(96.72% 0 0);
+  --primary-foreground: oklch(13.7% 0.024 251.41);
+
+  --secondary: oklch(25.21% 0.0058 271.18);
+  --secondary-foreground: oklch(96.72% 0 0);
+
+  --muted: oklch(21.32% 0.0042 264.48);
+  --muted-foreground: oklch(76.86% 0.0096 258.34);
+
+  --accent: oklch(29.92% 0.0029 17.32);
+  --accent-foreground: oklch(96.72% 0 0);
+
+  --destructive: oklch(44.64% 0.1063 31.61);
+
+  --border: oklch(28.16% 0.0047 174.1);
+  --input: oklch(34.66% 0.0103 253.97);
+  --ring: oklch(36.22% 0.0578 259.26);
+
+  --bg-gradient-start: oklch(13.7% 0.024 251.41);
+  --bg-gradient-middle: oklch(21.03% 0.0257 253.87);
+  --bg-gradient-end: oklch(0.137 0.024 251.41);
+
+  --tertiary: oklch(76.28% 0.1627 69.37);
+
+  --primary-gradient-start: oklch(59.17% 0.0998 259.93);
+  --primary-gradient-end: oklch(36.22% 0.0578 259.26);
 }
 
 @layer base {
@@ -89,6 +140,6 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-bg-gradient-start via-bg-gradient-middle to-bg-gradient-end text-foreground bg-gradient-to-br from-3% via-42% to-100%;
   }
 }


### PR DESCRIPTION
This pull request introduces changes to improve the default theme and enhance the styling with updated color variables and gradients. The most important updates include switching the default theme to "dark," redefining color variables for better contrast and aesthetics, and applying gradient backgrounds to the `body` element.

### Theme and Styling Updates:

* **Default Theme Change**: The default theme in `RootLayout` was updated from "system" to "dark" for a consistent user experience. (`src/app/[locale]/layout.tsx`, [src/app/[locale]/layout.tsxL37-R37](diffhunk://#diff-d387de9ed27220b8f151f3debc731746f2804b3e509aa2f99de6d40137df203aL37-R37))

* **Color Variable Redefinition**: Updated the `globals.css` file to redefine color variables for both light and dark themes, ensuring improved contrast and visual clarity. New variables for gradients and tertiary colors were also introduced. (`src/styles/globals.css`, [src/styles/globals.cssR25-R134](diffhunk://#diff-dd438e7ca4da8a47a35709920a07b6fef918609c1daa40f6e9b794ddfd3e4996R25-R134))

* **Gradient Background for `body`**: Applied a gradient background to the `body` element using the newly defined gradient variables, enhancing the visual appeal of the application. (`src/styles/globals.css`, [src/styles/globals.cssL92-R143](diffhunk://#diff-dd438e7ca4da8a47a35709920a07b6fef918609c1daa40f6e9b794ddfd3e4996L92-R143))