### PR TITLE
refactor(api): simplify axios setup by removing caching logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,2 @@
 VITE_API_KEY="super-secret-api-key"
-VITE_API_ORIGIN="http://localhost:3000"
-VITE_API_BASE_URL="https://indvprofile-api.example.com/api"
+VITE_API_BASE_URL="https://api.example.com/api"

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,7 +1,5 @@
 import { TRPCError } from '@trpc/server'
 import Axios from 'axios'
-import { buildStorage, setupCache } from 'axios-cache-interceptor'
-import { del, get, set } from 'idb-keyval'
 import { match } from 'ts-pattern'
 
 const indevproApi = Axios.create({
@@ -42,22 +40,6 @@ indevproApi.interceptors.response.use(
   }
 )
 
-const idbCacheStorage = buildStorage({
-  async find(key) {
-    const value = await get(key)
-    if (!value) return
-    return JSON.parse(value)
-  },
-  async set(key, value) {
-    await set(key, JSON.stringify(value))
-  },
-  async remove(key) {
-    await del(key)
-  }
-})
-
-const cachedIndevproApi = setupCache(indevproApi, { storage: idbCacheStorage })
-
 export const api = {
-  indevpro: cachedIndevproApi
+  indevpro: indevproApi
 }


### PR DESCRIPTION
This pull request simplifies the API configuration by removing IndexedDB-based caching and updating the API base URL environment variable. The main focus is on streamlining the code and ensuring the API points to the correct endpoint.

**API Configuration Updates:**

* Removed the IndexedDB caching logic from `src/lib/axios.ts`, including the use of `axios-cache-interceptor` and related code for building and managing the cache. Now, the `indevpro` API instance no longer uses a cache layer. [[1]](diffhunk://#diff-bfdb8aa3cd43a7af613c63ac93c06d0d320aa32aa153d3fdaf13db4d6a453f68L3-L4) [[2]](diffhunk://#diff-bfdb8aa3cd43a7af613c63ac93c06d0d320aa32aa153d3fdaf13db4d6a453f68L45-R44)

**Environment Variable Changes:**

* Updated the `VITE_API_BASE_URL` in `.env.example` to use `https://api.example.com/api` instead of the previous value, and removed the unused `VITE_API_ORIGIN` variable.