### PR TITLE
fix(about&home): add fallback image

### DIFF
--- a/src/components/about/cards/back.tsx
+++ b/src/components/about/cards/back.tsx
@@ -54,44 +54,50 @@ export default function MemberCardBack({
           src={member.image.back}
           alt={member.name}
           className="h-full w-full object-cover"
+          onError={e =>
+            (e.currentTarget.src =
+              'https://ik.imagekit.io/indevpro/non-formal/fallback.png')
+          }
         />
       </div>
       <div className="to-primary-gradient-start/60 absolute inset-x-0 bottom-0 bg-gradient-to-b from-transparent">
-        <ul className="relative flex h-fit w-full flex-row space-x-2 px-3 pb-1 lg:px-6 lg:py-4">
-          {member.socials.map((social, index) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <li key={`social-${index}`} className="flex items-center">
-              <TooltipProvider>
-                <Tooltip useTouch>
-                  <TooltipTrigger asChild>
-                    <a
-                      href={social.url ?? ''}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="group pointer-events-auto"
-                      onClick={e => {
-                        e.stopPropagation()
-                        e.preventDefault()
-                        window.open(
-                          social.url ?? '',
-                          '_blank',
-                          'noopener,noreferrer'
-                        )
-                      }}
-                    >
-                      <Icon
-                        className="hover:text-foreground/80 active:text-foreground/60 text-muted-foreground size-4 transition ease-out active:scale-95 lg:size-6"
-                        icon={getSocialIcon(social.slug)}
-                      />
-                    </a>
-                  </TooltipTrigger>
-                  <TooltipContent className="ml-2 flex flex-col items-center justify-center">
-                    {getSocialLabel(social.slug)}
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </li>
-          ))}
+        <ul className="relative flex h-fit w-full flex-row items-center gap-2 px-3 pb-2 lg:px-6 lg:py-4">
+          {member.socials
+            .filter(social => !!social.url)
+            .map((social, index) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <li key={`social-${index}`} className="flex items-center">
+                <TooltipProvider>
+                  <Tooltip useTouch>
+                    <TooltipTrigger asChild>
+                      <a
+                        href={social.url ?? ''}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="group pointer-events-auto"
+                        onClick={e => {
+                          e.stopPropagation()
+                          e.preventDefault()
+                          window.open(
+                            social.url ?? '',
+                            '_blank',
+                            'noopener,noreferrer'
+                          )
+                        }}
+                      >
+                        <Icon
+                          className="hover:text-foreground/80 active:text-foreground/60 text-muted-foreground size-4 transition ease-out active:scale-95 lg:size-6"
+                          icon={getSocialIcon(social.slug)}
+                        />
+                      </a>
+                    </TooltipTrigger>
+                    <TooltipContent className="ml-2 flex flex-col items-center justify-center">
+                      {getSocialLabel(social.slug)}
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </li>
+            ))}
         </ul>
       </div>
     </motion.div>

--- a/src/components/about/cards/front.tsx
+++ b/src/components/about/cards/front.tsx
@@ -31,6 +31,10 @@ export default function MemberCardFront({
         <img
           src={member.image.front}
           alt={member.name}
+          onError={e =>
+            (e.currentTarget.src =
+              'https://ik.imagekit.io/indevpro/formal/fallback.png')
+          }
           className="h-full w-full object-cover"
         />
       </div>

--- a/src/components/about/sections/grid.tsx
+++ b/src/components/about/sections/grid.tsx
@@ -60,11 +60,14 @@ export default function MembersGrid() {
 
   return (
     <>
-      <span ref={ref}></span>
       {members.map((member, index) => (
         // eslint-disable-next-line react/no-array-index-key
         <MemberCard key={`bento-card-member-${index}`} member={member} />
       ))}
+      {isFetchingNextPage && (
+        <Skeleton className="aspect-[3/4] w-full rounded-sm" />
+      )}
+      <span ref={ref}></span>
     </>
   )
 }

--- a/src/components/home/bento/team/pictures.tsx
+++ b/src/components/home/bento/team/pictures.tsx
@@ -97,7 +97,14 @@ export function TeamPictures({
                         transform: `translateX(${index * (isMobile ? 0.5 : 1)}rem)`
                       }}
                     >
-                      <AvatarImage src={member.imageUrl} alt={member.name} />
+                      <AvatarImage
+                        src={member.imageUrl}
+                        alt={member.name}
+                        onError={e =>
+                          (e.currentTarget.src =
+                            'https://ik.imagekit.io/indevpro/formal/fallback.png')
+                        }
+                      />
                       <AvatarFallback className="from-primary-gradient-start to-primary-gradient-end bg-gradient-to-br text-xs font-bold text-white md:text-sm lg:text-base">
                         {member.name.charAt(0).toUpperCase()}
                       </AvatarFallback>


### PR DESCRIPTION
This pull request improves the robustness and user experience of the member and team display components by adding fallback images for broken image links, filtering out invalid social links, and enhancing the loading state for the members grid. The most important changes are grouped below:

**Image Fallback Handling:**

* Added `onError` handlers to member and team images in `MemberCardFront`, `MemberCardBack`, and `TeamPictures` components to display a fallback image if the original image fails to load. [[1]](diffhunk://#diff-fe27c074acb8dfa68311136f5a7bdbe78dab1a739de0ad7a2efb8cc175a086aaR34-R37) [[2]](diffhunk://#diff-9b6cc357165c9a61fd41264c3adb6b70b12cd851d89bff422653f9da7fdbe836R57-R67) [[3]](diffhunk://#diff-e9439854befc367de4ba48a200c943cb75014fa5da4c521be63ba904a468a72aL100-R107)

**Social Links Filtering:**

* Updated the socials list in `MemberCardBack` to filter out social links without a URL, ensuring only valid links are displayed.

**Loading State Enhancement:**

* Improved the `MembersGrid` component by showing a skeleton loader when fetching additional members, providing better feedback during loading.